### PR TITLE
Do not convert \s5 into a paragraph node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 *.pyc
 .idea/*
+*.iml
 docs/translation/*

--- a/support/usxRenderer.py
+++ b/support/usxRenderer.py
@@ -181,7 +181,7 @@ class USXRenderer(abstractRenderer.AbstractRenderer):
     def renderS2(self, token):      self.f.write( self.stopAll() + u'\n\n<para style="s2">' + token.value + u'</para>' )
     def renderS3(self, token):      self.f.write( self.stopAll() + u'\n\n<para style="s3">' + token.value + u'</para>' )
     def renderS4(self, token):      self.f.write( self.stopAll() + u'\n\n<para style="s4">' + token.value + u'</para>' )
-    def renderS5(self, token):      self.f.write( self.stopAll() + u'\n\n<para style="s5">' + token.value + u'</para>' )
+    def renderS5(self, token):      self.f.write( self.stopC() + u'\n<note caller="u" style="s5"></note>' )
     def renderC(self, token):       self.currentC = token.value; self.currentV = u'0'; self.f.write( self.stopAll() + self.startC() )
     def renderCAS(self, token):     self.f.write( u' altnumber="' )
     def renderCAE(self, token):     self.f.write( u'"' )


### PR DESCRIPTION
When converting from USFM to USX, the \s5 tag cannot be brought over as a paragraph node. Since paragraphs cannot be nested, this causes the current paragraph to close prematurely and the remainder of the verses that are supposed to be in the paragraph are orphaned, not in any paragraph.  This is not valid USX,and it was interferring with the script that converts from USFM to translationStudio.

Instead of converting \s5 to a paragraph, I'm converting it to a user-defined note node.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword-dev/usfm-tools/21)

<!-- Reviewable:end -->
