### PR TITLE
Fixes bible and verse id= missing from singleHtmlRenderer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="usfm_tools",
-    version="0.0.11",
+    version="0.0.12",
     author="unfoldingWord",
     author_email="info@unfoldingWord.org",
     description="A framework for transforming .usfm files into specified targets",

--- a/test-setup.py
+++ b/test-setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="usfm_tools",
-    version="0.0.11",
+    version="0.0.12",
     author="unfoldingWord",
     author_email="info@unfoldingWord.org",
     description="A framework for transforming .usfm files into specified targets",

--- a/usfm_tools/support/singlehtmlRenderer.py
+++ b/usfm_tools/support/singlehtmlRenderer.py
@@ -183,14 +183,14 @@ class SingleHTMLRenderer(abstractRenderer.AbstractRenderer):
         self.writeFootnotes()
         self.footnote_num = 1
         self.cc = token.value.zfill(3)
-        #self.write(self.stopLI() + u'\n\n<h2 id="ch-'+self.cc+u'" class="c-num">'+self.chapterLabel+' ' + token.value + u'</h2>')
-        self.write(self.stopLI() + u'\n\n<h2 class="c-num">'+self.chapterLabel+' ' + token.value + u'</h2>')
+        self.write(self.stopLI() + u'\n\n<h2 id="{0}-ch-{1}" class="c-num">{2} {3}</h2>'
+                   .format(self.cb, self.cc, self.chapterLabel, token.value))
 
     def renderV(self, token):
         self.closeFootnote()
         self.cv = token.value.zfill(3)
-        #self.write(u' <span id="ch-'+self.cc+u'-v-'+self.cv+u'" class="v-num"><sup><b>' + token.value + u'</b></sup></span>')
-        self.write(u' <span class="v-num"><sup><b>' + token.value + u'</b></sup></span>')
+        self.write(u' <span id="{0}-ch-{1}-v-{2}" class="v-num"><sup><b>{3}</b></sup></span>'.
+                   format(self.cb, self.cc, self.cv, token.value))
 
     def renderWJS(self, token):
         self.write(u'<span class="woc">')


### PR DESCRIPTION
Found that we were using USFM-Tools v0.0.8 with tx-manager until now, v0.0.11 has chapters and verses no longer getting an id in their span tag. This is needed for the navigation in the project pages. Uncommented the line for the id= and make it use format() and also added the book number as there can be more than one book in a HTML page.