### PR TITLE
logging module so log output can be controlled externally

### DIFF
--- a/usfm_tools/__init__.py
+++ b/usfm_tools/__init__.py
@@ -1,0 +1,10 @@
+import logging
+
+# set up logging
+__logger = logging.getLogger('usfm_tools')
+__logger.setLevel(logging.INFO)
+__handler = logging.StreamHandler()
+__handler.setLevel(logging.INFO)
+__formatter = logging.Formatter("%(asctime)s %(name)s [%(levelname)s] %(message)s")
+__handler.setFormatter(__formatter)
+__logger.addHandler(__handler)

--- a/usfm_tools/support/books.py
+++ b/usfm_tools/support/books.py
@@ -3,6 +3,9 @@
 
 from __future__ import print_function, unicode_literals
 import os
+import logging
+
+__logger = logging.getLogger('usfm_tools')
 
 bookKeys = {
     'GEN': '001',
@@ -363,7 +366,7 @@ def bookName(usfm):
 def loadBooks(path):
     loaded_books = {}
     dirList = os.listdir(path)
-    print('\n     LOADING ALL USFM FILES FROM ' + path)
+    __logger.info('LOADING ALL USFM FILES FROM ' + path)
     for fname in dirList:
 
         full_file_name = os.path.join(path, fname)
@@ -382,10 +385,10 @@ def loadBooks(path):
                 loaded_books[bookID(usfm)] = usfm
                 f.close()
             else:
-                print('     Ignored ' + fname)
+                __logger.info('Ignored ' + fname)
         except:
-            print("     Couldn't open " + fname)
-    print('     FINISHED LOADING\n')
+            __logger.warning("Couldn't open " + fname)
+    __logger.info('FINISHED LOADING\n')
     return loaded_books
 
 

--- a/usfm_tools/support/parseUsfm.py
+++ b/usfm_tools/support/parseUsfm.py
@@ -5,7 +5,9 @@ from __future__ import print_function, unicode_literals
 import sys
 from pyparsing import Word, OneOrMore, nums, Literal, White, Group, Suppress, NoMatch, Optional, \
     CharsNotIn, MatchFirst
+import logging
 
+__logger = logging.getLogger('usfm_tools')
 
 def usfmToken(key):
     return Group(Suppress(backslash) + Literal(key) + Suppress(White()))
@@ -328,8 +330,8 @@ def parseString(unicodeString):
         cleaned = clean(unicodeString)
         tokens = usfm.parseString(cleaned, parseAll=True)
     except Exception as e:
-        print(e)
-        print(repr(unicodeString[:50]))
+        __logger.error(e)
+        __logger.error(repr(unicodeString[:50]))
         sys.exit()
     return [createToken(t) for t in tokens]
 

--- a/usfm_tools/support/singlehtmlRenderer.py
+++ b/usfm_tools/support/singlehtmlRenderer.py
@@ -44,7 +44,7 @@ class SingleHTMLRenderer(abstractRenderer.AbstractRenderer):
 
     def writeHeader(self):
         h = u"""
-        <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+        <!DOCTYP E html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
         <html xmlns="http://www.w3.org/1999/xhtml">
         <head>
             <meta http-equiv="content-type" content="text/html; charset=utf-8"></meta>

--- a/usfm_tools/support/singlehtmlRenderer.py
+++ b/usfm_tools/support/singlehtmlRenderer.py
@@ -44,7 +44,7 @@ class SingleHTMLRenderer(abstractRenderer.AbstractRenderer):
 
     def writeHeader(self):
         h = u"""
-        <!DOCTYP E html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+        <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
         <html xmlns="http://www.w3.org/1999/xhtml">
         <head>
             <meta http-equiv="content-type" content="text/html; charset=utf-8"></meta>

--- a/usfm_tools/support/usxRenderer.py
+++ b/usfm_tools/support/usxRenderer.py
@@ -4,7 +4,7 @@
 from __future__ import print_function, unicode_literals
 import abstractRenderer
 import codecs
-
+import logging
 
 #
 #   Simplest renderer. Ignores everything except ascii text.
@@ -32,11 +32,12 @@ class USXRenderer(abstractRenderer.AbstractRenderer):
                              'cell': False, 'table': False}
         # Errors
         self.error = ''
+        self.__logger = logging.getLogger('usfm_tools')
 
     def render(self):
         self.loadUSFM(self.inputDir)
         if self.byBook:
-            print('#### Creating One File Per Book\n')
+            self.__logger.info('Creating One File Per Book\n')
             for bookName in self.booksUsfm:
                 self.f = codecs.open(self.outputFilePath + bookName + self.outputFileExt, 'w', 'utf_8_sig')
                 self.renderBook = bookName
@@ -44,15 +45,15 @@ class USXRenderer(abstractRenderer.AbstractRenderer):
                 self.f.write(self.stop_all())
                 self.f.close()
         else:
-            print('#### Concatenating Books into ' + self.outputFileName + self.outputFileExt + '\n')
+            self.__logger.info('Concatenating Books into ' + self.outputFileName + self.outputFileExt + '\n')
             self.f = codecs.open(self.outputFilePath + self.outputFileName + self.outputFileExt, 'w', 'utf_8_sig')
             self.run()
             self.f.write(self.stop_p() + self.stop_pi() + self.stop_pi2() + self.stop_q() + self.stop_li())
             self.f.close()
-        print('')
+        self.__logger.info('')
 
     def writeLog(self, s):
-        print(s)
+        self.__logger.info(s)
 
     # Support
 
@@ -521,5 +522,5 @@ class USXRenderer(abstractRenderer.AbstractRenderer):
     def renderUnknown(self, token):
         if token.value == 'v':
             self.currentV = int(self.currentV) + 1
-        print('     Error: ' + self.renderBook + ' ' + str(self.currentC) + ':' + str(self.currentV) +
+        self.__logger.error(self.renderBook + ' ' + str(self.currentC) + ':' + str(self.currentV) +
               ' - Unknown Token: \\' + self.escape(token.value))


### PR DESCRIPTION
This is a minor change to introduce support for using the logging module. Doing so will allow external code to control log output from usfm_tools. This can be particularly helpful in reducing log noise in long running processes such as the v3 API generator.